### PR TITLE
Add default footer informations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add more default props.
 
 ## [1.0.7] - 2018-10-31
 ### Fixed

--- a/react/defaultProps.json
+++ b/react/defaultProps.json
@@ -5,38 +5,9 @@
         {
             "socialNetwork": "Facebook",
             "url": "#"
-        },
-        {
-            "socialNetwork": "Twitter",
-            "url": "#"
-        },
-        {
-            "socialNetwork": "Instagram",
-            "url": "#"
         }
     ],
     "sectionLinks": [
-        {
-            "title": "Know more about us",
-            "links": [
-                {
-                    "title": "Extended Warranty",
-                    "url": "#"
-                },
-                {
-                    "title": "Investor Relations",
-                    "url": "#"
-                },
-                {
-                    "title": "Careers",
-                    "url": "#"
-                },
-                {
-                    "title": "Privacy Policy",
-                    "url": "#"
-                }
-            ]
-        },
         {
             "title": "Talk to us",
             "links": [
@@ -57,27 +28,6 @@
                     "url": "#"
                 }
             ]
-        },
-        {
-            "title": "Our Card",
-            "links": [
-                {
-                    "title": "Get yours!",
-                    "url": "#"
-                },
-                {
-                    "title": "Special Offers",
-                    "url": "#"
-                },
-                {
-                    "title": "Travel Miles",
-                    "url": "#"
-                },
-                {
-                    "title": "Benefits",
-                    "url": "#"
-                }
-            ]
         }
     ],
     "badges": [],
@@ -89,22 +39,11 @@
                 "Visa",
                 "Diners Club"
             ]
-        },
-        {
-            "title": "Debit",
-            "paymentTypes": [
-                "MasterCard",
-                "Visa",
-                "Diners Club"
-            ]
         }
     ],
     "storeInformations": [
         {
             "storeInformation": "All the rules and promotions are only valid for products sold and delivered by our store. The product's offer price will be granted after the sale conclusion. If there's divergence, the lower price shall prevail."
-        },
-        {
-            "storeInformation": "CNPJ n.º 01.002.333/0001-00 | Centro Empresarial Botafogo - Praia de Botafogo, 300 - 2º Andar - Botafogo, Rio de Janeiro - RJ, 22250-040- a VTEX group company."
         }
     ]
 }

--- a/react/defaultProps.json
+++ b/react/defaultProps.json
@@ -1,0 +1,110 @@
+{
+    "showPaymentFormsInColor": false,
+    "showsocialNetworksInColor": false,
+    "socialNetworks": [
+        {
+            "socialNetwork": "Facebook",
+            "url": "#"
+        },
+        {
+            "socialNetwork": "Twitter",
+            "url": "#"
+        },
+        {
+            "socialNetwork": "Instagram",
+            "url": "#"
+        }
+    ],
+    "sectionLinks": [
+        {
+            "title": "Know more about us",
+            "links": [
+                {
+                    "title": "Extended Warranty",
+                    "url": "#"
+                },
+                {
+                    "title": "Investor Relations",
+                    "url": "#"
+                },
+                {
+                    "title": "Careers",
+                    "url": "#"
+                },
+                {
+                    "title": "Privacy Policy",
+                    "url": "#"
+                }
+            ]
+        },
+        {
+            "title": "Talk to us",
+            "links": [
+                {
+                    "title": "Attendance",
+                    "url": "#"
+                },
+                {
+                    "title": "Returns & Replacements",
+                    "url": "#"
+                },
+                {
+                    "title": "Buyers Remorse",
+                    "url": "#"
+                },
+                {
+                    "title": "Shipping Policies",
+                    "url": "#"
+                }
+            ]
+        },
+        {
+            "title": "Our Card",
+            "links": [
+                {
+                    "title": "Get yours!",
+                    "url": "#"
+                },
+                {
+                    "title": "Special Offers",
+                    "url": "#"
+                },
+                {
+                    "title": "Travel Miles",
+                    "url": "#"
+                },
+                {
+                    "title": "Benefits",
+                    "url": "#"
+                }
+            ]
+        }
+    ],
+    "badges": [],
+    "paymentForms": [
+        {
+            "title": "editor.footer.paymentForms.paymentForm",
+            "paymentTypes": [
+                "MasterCard",
+                "Visa",
+                "Diners Club"
+            ]
+        },
+        {
+            "title": "Debit",
+            "paymentTypes": [
+                "MasterCard",
+                "Visa",
+                "Diners Club"
+            ]
+        }
+    ],
+    "storeInformations": [
+        {
+            "storeInformation": "Todas as regras e promoções são válidas apenas para produtos vendidos e entregues pela nossa Loja. O valor de oferta do produto será garantido após a finalização da compra. Havendo divergência, prevalecerá o menor preço ofertado."
+        },
+        {
+            "storeInformation": "CNPJ n.º 01.002.333/0001-00 | Centro Empresarial Botafogo - Praia de Botafogo, 300 - 2º Andar - Botafogo, Rio de Janeiro - RJ, 22250-040- empresa do grupo VTEX."
+        }
+    ]
+}

--- a/react/defaultProps.json
+++ b/react/defaultProps.json
@@ -1,49 +1,49 @@
 {
-    "showPaymentFormsInColor": false,
-    "showsocialNetworksInColor": false,
-    "socialNetworks": [
+  "showPaymentFormsInColor": false,
+  "showsocialNetworksInColor": false,
+  "socialNetworks": [
+    {
+      "socialNetwork": "Facebook",
+      "url": "#"
+    }
+  ],
+  "sectionLinks": [
+    {
+      "title": "Talk to us",
+      "links": [
         {
-            "socialNetwork": "Facebook",
-            "url": "#"
-        }
-    ],
-    "sectionLinks": [
+          "title": "Attendance",
+          "url": "#"
+        },
         {
-            "title": "Talk to us",
-            "links": [
-                {
-                    "title": "Attendance",
-                    "url": "#"
-                },
-                {
-                    "title": "Returns & Replacements",
-                    "url": "#"
-                },
-                {
-                    "title": "Buyers Remorse",
-                    "url": "#"
-                },
-                {
-                    "title": "Shipping Policies",
-                    "url": "#"
-                }
-            ]
-        }
-    ],
-    "badges": [],
-    "paymentForms": [
+          "title": "Returns & Replacements",
+          "url": "#"
+        },
         {
-            "title": "editor.footer.paymentForms.paymentForm",
-            "paymentTypes": [
-                "MasterCard",
-                "Visa",
-                "Diners Club"
-            ]
-        }
-    ],
-    "storeInformations": [
+          "title": "Buyers Remorse",
+          "url": "#"
+        },
         {
-            "storeInformation": "All the rules and promotions are only valid for products sold and delivered by our store. The product's offer price will be granted after the sale conclusion. If there's divergence, the lower price shall prevail."
+          "title": "Shipping Policies",
+          "url": "#"
         }
-    ]
+      ]
+    }
+  ],
+  "badges": [],
+  "paymentForms": [
+    {
+      "title": "editor.footer.paymentForms.paymentForm",
+      "paymentTypes": [
+        "MasterCard",
+        "Visa",
+        "Diners Club"
+      ]
+    }
+  ],
+  "storeInformations": [
+    {
+      "storeInformation": "All the rules and promotions are only valid for products sold and delivered by our store. The product's offer price will be granted after the sale conclusion. If there's divergence, the lower price shall prevail."
+    }
+  ]
 }

--- a/react/defaultProps.json
+++ b/react/defaultProps.json
@@ -101,10 +101,10 @@
     ],
     "storeInformations": [
         {
-            "storeInformation": "Todas as regras e promoções são válidas apenas para produtos vendidos e entregues pela nossa Loja. O valor de oferta do produto será garantido após a finalização da compra. Havendo divergência, prevalecerá o menor preço ofertado."
+            "storeInformation": "All the rules and promotions are only valid for products sold and delivered by our store. The product's offer price will be granted after the sale conclusion. If there's divergence, the lower price shall prevail."
         },
         {
-            "storeInformation": "CNPJ n.º 01.002.333/0001-00 | Centro Empresarial Botafogo - Praia de Botafogo, 300 - 2º Andar - Botafogo, Rio de Janeiro - RJ, 22250-040- empresa do grupo VTEX."
+            "storeInformation": "CNPJ n.º 01.002.333/0001-00 | Centro Empresarial Botafogo - Praia de Botafogo, 300 - 2º Andar - Botafogo, Rio de Janeiro - RJ, 22250-040- a VTEX group company."
         }
     ]
 }

--- a/react/defaultProps.json
+++ b/react/defaultProps.json
@@ -44,6 +44,9 @@
   "storeInformations": [
     {
       "storeInformation": "All the rules and promotions are only valid for products sold and delivered by our store. The product's offer price will be granted after the sale conclusion. If there's divergence, the lower price shall prevail."
+    },
+    {
+      "storeInformation": "CNPJ n.º 01.002.333/0001-00 | Centro Empresarial Botafogo - Praia de Botafogo, 300 - 2º Andar - Botafogo, Rio de Janeiro - RJ, 22250-040- a VTEX group company."
     }
   ]
 }

--- a/react/index.js
+++ b/react/index.js
@@ -9,6 +9,7 @@ import FooterLinksMatrix from './components/FooterLinksMatrix'
 import FooterPaymentFormMatrix from './components/FooterPaymentFormMatrix'
 import FooterVtexLogo from './components/FooterVtexLogo'
 import FooterSocialNetworkList from './components/FooterSocialNetworkList'
+import footerDefaultProps from './defaultProps.json'
 import { objectLikeBadgeArray, objectLikeLinkArray } from './propTypes'
 
 /**
@@ -51,25 +52,7 @@ export default class Footer extends Component {
     storeInformations: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.string)),
   }
 
-  static defaultProps = {
-    showPaymentFormsInColor: false,
-    showSocialNetworksInColor: false,
-    socialNetworks: [
-      {
-        socialNetwork: 'Facebook',
-        url: '#',
-      },
-    ],
-    sectionLinks: [],
-    badges: [],
-    paymentForms: [
-      {
-        title: 'editor.footer.paymentForms.paymentForm',
-        paymentTypes: ['MasterCard'],
-      },
-    ],
-    storeInformations: [],
-  }
+  static defaultProps = footerDefaultProps
 
   static schema = {
     title: 'editor.footer.title',
@@ -218,7 +201,7 @@ export default class Footer extends Component {
 
   getInformationCssClasses = (listLength, index) => {
     let paddingClass
-    const defaultClasses = 'vtex-footer__text-information w-100 w-50-ns pa3-ns f7 ma0'
+    const defaultClasses = 'vtex-footer__text-information w-100 w-50-ns pa3-ns t-small ma0'
     // Only apply vertical paddings if there is more than 1 element
     if (listLength > 1) {
       if (index === 0) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Add values to defaultProps of dreamstore footer.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The footer had no information, so when the client used the component it was all blank. The default props also offer an example of the props the footer can have.

#### How should this be manually tested?
[Component link](https://defaultfooterinfo--storecomponents.myvtex.com/_v/app/vtex.dreamstore-footer@1.0.7/react/index)

#### Screenshots or example usage
*Before*
![captura de tela de 2018-11-07 11-11-51](https://user-images.githubusercontent.com/4912690/48136412-5daa5200-e27e-11e8-947a-e57258757cb9.png)

*After*
![captura de tela de 2018-11-07 11-13-53](https://user-images.githubusercontent.com/4912690/48136424-6438c980-e27e-11e8-9f99-6a45b79e9b19.png)

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

