### PR TITLE
Fix/footer padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix footer padding to be aligned with the other page elements.
 
 ## [2.5.0] - 2019-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.5.1] - 2019-01-26
 ### Fixed
 - Fix footer padding to be aligned with the other page elements.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-footer",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "title": "VTEX Store Footer component",
   "defaultLocale": "pt-BR",
   "description": "The canonical VTEX store footer component",

--- a/react/index.js
+++ b/react/index.js
@@ -249,7 +249,7 @@ export default class Footer extends Component {
       <footer className={`${footer.footer} bt bw1 b--muted-4 mt4 pv5`}>
         <Container className="justify-center flex">
           <div className="w-100 mw9">
-            <nav className={`${footer.container} pt5-s flex justify-between ph4-s bg-base c-muted-1`}>
+            <nav className={`${footer.container} pt5-s flex justify-between bg-base c-muted-1`}>
               <div className={`${footer.linksContainer} t-small w-100-s w-80-ns pb5-s`}>
                 <FooterLinksMatrix links={sectionLinks} />
               </div>
@@ -264,14 +264,14 @@ export default class Footer extends Component {
                 />
               </div>
             </nav>
-            <div className={`${footer.container} pv5-s flex justify-between ph4-s bg-base c-muted-1`}>
+            <div className={`${footer.container} pv5-s flex justify-between bg-base c-muted-1`}>
               <FooterPaymentFormMatrix
                 paymentForms={paymentForms}
                 horizontal
                 showInColor={showPaymentFormsInColor}
               />
             </div>
-            <div className={`${footer.container} pt5-s flex justify-between ph4-s bg-base c-muted-1`}>
+            <div className={`${footer.container} pt5-s flex justify-between bg-base c-muted-1`}>
               <div className={`${footer.textContainer} w-100-s pb5-s w-80-ns flex flex-wrap`}>
                 {storeInformations &&
                   storeInformations.map(({ storeInformation }, index) => (


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove ph4-s class from footer elements.

#### What problem is this solving?
This change solves the misalignment among the footer and the other elements of the page.

#### How should this be manually tested?
Opening the product details, for example, and checking the misalignment between the product description and footer links.

#### Screenshots or example usage
Before
![captura de tela de 2019-01-16 10-09-43](https://user-images.githubusercontent.com/9946330/51251493-3c4d9c80-1978-11e9-8495-eeed984f2ec1.png)

After
![captura de tela de 2019-01-16 10-10-36](https://user-images.githubusercontent.com/9946330/51251521-4cfe1280-1978-11e9-83c3-67e66d60b39b.png)

[Workspace Link](https://storefooteralignment--storecomponents.myvtex.com/)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

