### PR TITLE
Fix: stop rendering blank logo image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Check if prop logoUrl exists before render, preventing to render a inexistent image
+
 ## [2.6.11] - 2019-03-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.12] - 2019-03-07
+
 ### Fixed
 
 - Check if prop logoUrl exists before render, preventing to render a inexistent image

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-footer",
-  "version": "2.6.11",
+  "version": "2.6.12",
   "title": "VTEX Store Footer component",
   "defaultLocale": "pt-BR",
   "description": "The canonical VTEX store footer component",

--- a/react/components/FooterVtexLogo.js
+++ b/react/components/FooterVtexLogo.js
@@ -25,9 +25,11 @@ const FooterVtexLogo = ({ runtime, logoUrl, imageSrc }) => {
 
   return (
     <div className={`${footer.badgeList} flex flex-row justify-center pv4-s pa0-ns items-center ml-auto-m`}>
-      <span className={`${footer.badge} pa2-s pa1-ns`}>
-        <img className={`${footer.logoImage} h3`} src={logoUrl} />
-      </span>
+      {logoUrl && 
+        <span className={`${footer.badge} pa2-s pa1-ns`}>
+          <img className={`${footer.logoImage} h3`} src={logoUrl} />
+        </span>
+      }
       <span className={`${footer.badge} pa2-s pa1-ns nt7-ns`}>
         <img className={vtexLogoItemClasses} src={imageSrc} />
       </span>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Stop render logo image on footer when not exists prop `logoUrl`

#### What problem is this solving?
Prevent to render a blank image and unnecessary html tags with paddings that are causing decentralization of elements

![image](https://user-images.githubusercontent.com/5813213/53969151-022a8c80-40d7-11e9-9b49-c9189d4dd7c2.png)

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

