### PR TITLE
Add prop target to links in sectionLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- sectionLinks now contains the prop `target` in links where is possible to use one of the values `[self_tab, new_tab]`. `self_tab` it means the value for target attribute it will be `_self`. `new_tab` it will be `_blank`
+- sectionLinks now contains the prop `target` in links where is possible to use one of the values `[_self_, _blank_]`. That will define the value for target attribute. `<a href="/" target="_self">`
 
 ## [2.6.13] - 2019-03-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.6.14] - 2019-03-18
 ### Added
 - sectionLinks now contains the prop `target` in links where is possible to use one of the values `[_self_, _blank_]`. That will define the value for target attribute. `<a href="/" target="_self">`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- sectionLinks now contains the prop `target` in links where is possible to use one of values `[self_tab, new_tab]`. `self_tab` it means the value for target attribute it will be `_self`. `new_tab` it will be `_blank`
 
 ## [2.6.13] - 2019-03-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- sectionLinks now contains the prop `target` in links where is possible to use one of values `[self_tab, new_tab]`. `self_tab` it means the value for target attribute it will be `_self`. `new_tab` it will be `_blank`
+- sectionLinks now contains the prop `target` in links where is possible to use one of the values `[self_tab, new_tab]`. `self_tab` it means the value for target attribute it will be `_self`. `new_tab` it will be `_blank`
 
 ## [2.6.13] - 2019-03-14
 ### Changed

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Now, you can change the behavior of the footer block. See an example of how to c
     ],
     "sectionLinks": [
       {"title": "About us", "links":[
-        { "url":"www.mystore.com/faq", "title":"FAQ" },
-        { "url":"www.mystore.com/talktous", "title":"Talk to us" }
+        { "url":"www.mystore.com/faq", "title":"FAQ", "target": "new_tab" },
+        { "url":"www.mystore.com/talktous", "title":"Talk to us", "target": "self_tab" }
       ]}
     ],
     "storeInformations": ["CNPJ n.º 1231132.231.1231/000", "All the rights reserved."],
@@ -123,6 +123,7 @@ Link:
 | --------- | -------- | ----------------- |
 | `url`     | `String` | URL               |
 | `title`   | `String` | Title of the link |
+| `target`  | `Enum`   | Target of the link. (values: `self_tab` or `new_tab`) |
 
 Badge:
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Now, you can change the behavior of the footer block. See an example of how to c
     ],
     "sectionLinks": [
       {"title": "About us", "links":[
-        { "url":"www.mystore.com/faq", "title":"FAQ", "target": "new_tab" },
-        { "url":"www.mystore.com/talktous", "title":"Talk to us", "target": "self_tab" }
+        { "url":"www.mystore.com/faq", "title":"FAQ", "target": "_blank" },
+        { "url":"www.mystore.com/talktous", "title":"Talk to us", "target": "_self" }
       ]}
     ],
     "storeInformations": ["CNPJ n.º 1231132.231.1231/000", "All the rights reserved."],
@@ -123,7 +123,7 @@ Link:
 | --------- | -------- | ----------------- |
 | `url`     | `String` | URL               |
 | `title`   | `String` | Title of the link |
-| `target`  | `Enum`   | Target of the link. (values: `self_tab` or `new_tab`) |
+| `target`  | `Enum`   | Target of the link. (values: `_self` or `_blank`) |
 
 Badge:
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-footer",
-  "version": "2.6.13",
+  "version": "2.6.14",
   "title": "VTEX Store Footer component",
   "defaultLocale": "pt-BR",
   "description": "The canonical VTEX store footer component",

--- a/messages/context.json
+++ b/messages/context.json
@@ -21,6 +21,7 @@
   "editor.footer.linksSections.linksSection.links.link": "editor.footer.linksSections.linksSection.links.link",
   "editor.footer.linksSections.linksSection.links.link.title": "editor.footer.linksSections.linksSection.links.link.title",
   "editor.footer.linksSections.linksSection.links.link.url": "editor.footer.linksSections.linksSection.links.link.url",
+  "editor.footer.linksSections.linksSection.links.link.target": "editor.footer.linksSections.linksSection.links.link.target",
   "editor.footer.moreInformationLink": "editor.footer.moreInformationLink",
   "editor.footer.moreInformationLink.title": "editor.footer.moreInformationLink.title",
   "editor.footer.badge": "editor.footer.badge",

--- a/messages/context.json
+++ b/messages/context.json
@@ -22,6 +22,8 @@
   "editor.footer.linksSections.linksSection.links.link.title": "editor.footer.linksSections.linksSection.links.link.title",
   "editor.footer.linksSections.linksSection.links.link.url": "editor.footer.linksSections.linksSection.links.link.url",
   "editor.footer.linksSections.linksSection.links.link.target": "editor.footer.linksSections.linksSection.links.link.target",
+  "editor.footer.linksSections.linksSection.links.link.target.self": "editor.footer.linksSections.linksSection.links.link.target.self",
+  "editor.footer.linksSections.linksSection.links.link.target.blank": "editor.footer.linksSections.linksSection.links.link.target.blank",
   "editor.footer.moreInformationLink": "editor.footer.moreInformationLink",
   "editor.footer.moreInformationLink.title": "editor.footer.moreInformationLink.title",
   "editor.footer.badge": "editor.footer.badge",

--- a/messages/en.json
+++ b/messages/en.json
@@ -22,6 +22,8 @@
   "editor.footer.linksSections.linksSection.links.link.title": "Link Title",
   "editor.footer.linksSections.linksSection.links.link.url": "Link URL",
   "editor.footer.linksSections.linksSection.links.link.target": "Link Target",
+  "editor.footer.linksSections.linksSection.links.link.target.self": "Current browser tab",
+  "editor.footer.linksSections.linksSection.links.link.target.blank": "New browser tab",
   "editor.footer.moreInformationLink": "More Information Links",
   "editor.footer.moreInformationLink.title": "More Information Link",
   "editor.footer.badge": "Badges",

--- a/messages/en.json
+++ b/messages/en.json
@@ -21,6 +21,7 @@
   "editor.footer.linksSections.linksSection.links.link": "Link",
   "editor.footer.linksSections.linksSection.links.link.title": "Link Title",
   "editor.footer.linksSections.linksSection.links.link.url": "Link URL",
+  "editor.footer.linksSections.linksSection.links.link.target": "Link Target",
   "editor.footer.moreInformationLink": "More Information Links",
   "editor.footer.moreInformationLink.title": "More Information Link",
   "editor.footer.badge": "Badges",

--- a/messages/es.json
+++ b/messages/es.json
@@ -21,6 +21,7 @@
   "editor.footer.linksSections.linksSection.links.link": "Enlace",
   "editor.footer.linksSections.linksSection.links.link.title": "Título del Enlace",
   "editor.footer.linksSections.linksSection.links.link.url": "URL del Enlace",
+  "editor.footer.linksSections.linksSection.links.link.target": "Objetivo del Enlace",
   "editor.footer.moreInformationLink": "Enlaces para más información",
   "editor.footer.moreInformationLink.title": "Enlace para más información",
   "editor.footer.badge": "Medallas",

--- a/messages/es.json
+++ b/messages/es.json
@@ -22,6 +22,8 @@
   "editor.footer.linksSections.linksSection.links.link.title": "Título del Enlace",
   "editor.footer.linksSections.linksSection.links.link.url": "URL del Enlace",
   "editor.footer.linksSections.linksSection.links.link.target": "Objetivo del Enlace",
+  "editor.footer.linksSections.linksSection.links.link.target.self": "Pestaña actual del navegador",
+  "editor.footer.linksSections.linksSection.links.link.target.blank": "Nueva pestaña del navegador",
   "editor.footer.moreInformationLink": "Enlaces para más información",
   "editor.footer.moreInformationLink.title": "Enlace para más información",
   "editor.footer.badge": "Medallas",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -22,6 +22,8 @@
   "editor.footer.linksSections.linksSection.links.link.title": "Título do link",
   "editor.footer.linksSections.linksSection.links.link.url": "URL do link",
   "editor.footer.linksSections.linksSection.links.link.target": "Objetivo do link",
+  "editor.footer.linksSections.linksSection.links.link.target.self": "Janela atual do browser",
+  "editor.footer.linksSections.linksSection.links.link.target.blank": "Nova janela do browser",
   "editor.footer.badge": "Medalhas",
   "editor.footer.badge.title": "Medalha",
   "editor.footer.badge.image.title": "URL da imagem da medalha",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -21,6 +21,7 @@
   "editor.footer.linksSections.linksSection.links.link": "Link",
   "editor.footer.linksSections.linksSection.links.link.title": "Título do link",
   "editor.footer.linksSections.linksSection.links.link.url": "URL do link",
+  "editor.footer.linksSections.linksSection.links.link.target": "Objetivo do link",
   "editor.footer.badge": "Medalhas",
   "editor.footer.badge.title": "Medalha",
   "editor.footer.badge.image.title": "URL da imagem da medalha",

--- a/react/__tests__/__snapshots__/Footer.test.js.snap
+++ b/react/__tests__/__snapshots__/Footer.test.js.snap
@@ -38,6 +38,7 @@ exports[`<Footer /> component should match the snapshot 1`] = `
                       <a
                         class="listLink dib no-underline underline-hover mb0 mt2 w-100 t-small truncate c-muted-1 pointer"
                         href="mockedUrl"
+                        target="_self"
                       >
                         Some title
                       </a>
@@ -85,6 +86,7 @@ exports[`<Footer /> component should match the snapshot 1`] = `
                           <a
                             class="listLink dib no-underline underline-hover mb0 mt2 w-100 t-small truncate c-muted-1 pointer"
                             href="mockedUrl"
+                            target="_self"
                           >
                             Some title
                           </a>

--- a/react/components/FooterLinkList.js
+++ b/react/components/FooterLinkList.js
@@ -4,16 +4,12 @@ import React from 'react'
 import footerList from './footerList'
 import footer from '../footer.css'
 
-const targetByType = {
-  self_tab: '_self', 
-  new_tab: '_blank'
-}
 
 export const FooterLinkItem = ({ url, title, target }) => (
   <a
     className={`${footer.listLink} dib no-underline underline-hover mb0 mt2 w-100 t-small truncate c-muted-1 pointer`}
     href={url}
-    target={target ? targetByType[target] : '_self'}
+    target={target ? target : '_self'}
   >
     {title}
   </a>
@@ -24,7 +20,7 @@ FooterLinkItem.displayName = 'FooterLinkItem'
 FooterLinkItem.propTypes = {
   url: PropTypes.string,
   title: PropTypes.string.isRequired,
-  target: PropTypes.oneOf(['self_tab', 'new_tab'])
+  target: PropTypes.oneOf(['_self', '_blank'])
 }
 
 export default footerList(FooterLinkItem)

--- a/react/components/FooterLinkList.js
+++ b/react/components/FooterLinkList.js
@@ -4,10 +4,16 @@ import React from 'react'
 import footerList from './footerList'
 import footer from '../footer.css'
 
-export const FooterLinkItem = ({ url, title }) => (
+const targetByType = {
+  self_tab: '_self', 
+  new_tab: '_blank'
+}
+
+export const FooterLinkItem = ({ url, title, target }) => (
   <a
     className={`${footer.listLink} dib no-underline underline-hover mb0 mt2 w-100 t-small truncate c-muted-1 pointer`}
     href={url}
+    target={target ? targetByType[target] : '_self'}
   >
     {title}
   </a>
@@ -18,6 +24,7 @@ FooterLinkItem.displayName = 'FooterLinkItem'
 FooterLinkItem.propTypes = {
   url: PropTypes.string,
   title: PropTypes.string.isRequired,
+  target: PropTypes.oneOf(['self_tab', 'new_tab'])
 }
 
 export default footerList(FooterLinkItem)

--- a/react/components/FooterLinksMatrix.js
+++ b/react/components/FooterLinksMatrix.js
@@ -3,6 +3,7 @@ import React, { Component, Fragment } from 'react'
 
 import Accordion from './Accordion'
 import FooterLinkList, { FooterLinkItem } from './FooterLinkList'
+import { objectLikeLinkArray } from './../propTypes'
 import footer from '../footer.css'
 
 export default class FooterLinksMatrix extends Component {
@@ -13,12 +14,7 @@ export default class FooterLinksMatrix extends Component {
         /** Link section title */
         title: PropTypes.string.isRequired,
         /** Link section links */
-        links: PropTypes.arrayOf(
-          PropTypes.shape({
-            /** Link text */
-            title: PropTypes.string.isRequired,
-          })
-        ),
+        links: objectLikeLinkArray,
       })
     ),
   }

--- a/react/index.js
+++ b/react/index.js
@@ -156,6 +156,13 @@ export default class Footer extends Component {
                       'editor.footer.linksSections.linksSection.links.link.url',
                     type: 'string',
                   },
+                  target: {
+                    title:
+                      'editor.footer.linksSections.linksSection.links.link.target',
+                    type: 'string',
+                    default: 'self_tab',
+                    enum: ['self_tab', 'new_tab'],
+                  },
                 },
               },
             },

--- a/react/index.js
+++ b/react/index.js
@@ -160,8 +160,12 @@ export default class Footer extends Component {
                     title:
                       'editor.footer.linksSections.linksSection.links.link.target',
                     type: 'string',
-                    default: 'self_tab',
-                    enum: ['self_tab', 'new_tab'],
+                    default: '_self',
+                    enum: ['_self', '_blank'],
+                    enumNames: [
+                      'editor.footer.linksSections.linksSection.links.link.target.self',
+                      'editor.footer.linksSections.linksSection.links.link.target.blank',
+                    ],
                   },
                 },
               },
@@ -266,7 +270,11 @@ export default class Footer extends Component {
       <footer className={`${footer.footer} bt bw1 b--muted-4 mt4 pv5`}>
         <Container className="justify-center flex">
           <div className="w-100 mw9">
-            <nav className={`${footer.container} ${footer.navigation} pt5-s flex justify-between bg-base c-muted-1`}>
+            <nav
+              className={`${footer.container} ${
+                footer.navigation
+              } pt5-s flex justify-between bg-base c-muted-1`}
+            >
               <div className={`${footer.links} t-small w-100-s w-80-ns pb5-s`}>
                 <FooterLinksMatrix links={sectionLinks} />
               </div>
@@ -281,26 +289,44 @@ export default class Footer extends Component {
                 />
               </div>
             </nav>
-            <div className={`${footer.container} ${footer.payment} pv5-s flex justify-between bg-base c-muted-1`}>
+            <div
+              className={`${footer.container} ${
+                footer.payment
+              } pv5-s flex justify-between bg-base c-muted-1`}
+            >
               <FooterPaymentFormMatrix
                 paymentForms={paymentForms}
                 horizontal
                 showInColor={showPaymentFormsInColor}
               />
             </div>
-            <div className={`${footer.container} ${footer.informationContainer} pt5-s flex justify-between bg-base c-muted-1`}>
-              <div className={`${footer.textContainer} w-100-s pb5-s w-80-ns flex flex-wrap`}>
+            <div
+              className={`${footer.container} ${
+                footer.informationContainer
+              } pt5-s flex justify-between bg-base c-muted-1`}
+            >
+              <div
+                className={`${
+                  footer.textContainer
+                } w-100-s pb5-s w-80-ns flex flex-wrap`}
+              >
                 {storeInformations &&
                   storeInformations.map(({ storeInformation }, index) => (
                     <p
                       key={`information-${index}`}
-                      className={this.getInformationCssClasses(storeInformations.length, index)}
+                      className={this.getInformationCssClasses(
+                        storeInformations.length,
+                        index
+                      )}
                     >
                       {storeInformation}
                     </p>
                   ))}
               </div>
-              <FooterVtexLogo logoUrl={logo} showInColor={showVtexLogoInColor} />
+              <FooterVtexLogo
+                logoUrl={logo}
+                showInColor={showVtexLogoInColor}
+              />
               <FooterBadgeList list={badges} />
             </div>
           </div>

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -4,7 +4,7 @@ export const objectLikeLinkArray = PropTypes.arrayOf(
   PropTypes.shape({
     url: PropTypes.string,
     title: PropTypes.string,
-    target: PropTypes.oneOf(['self_tab', 'new_tab'])
+    target: PropTypes.oneOf(['_self', '_blank']),
   })
 )
 

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -4,6 +4,7 @@ export const objectLikeLinkArray = PropTypes.arrayOf(
   PropTypes.shape({
     url: PropTypes.string,
     title: PropTypes.string,
+    target: PropTypes.oneOf(['self_tab', 'new_tab'])
   })
 )
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add prop `target` in the sectionLinks
Closes #33 

#### What problem is this solving?
Currently is not possible to change the way to open a link in sectionLinks. This PR is going to be capable to add a prop `target` in `links` inside `sectionLinks` where is possible to use one of the values `[_self, _blank]`.

`_self` it will open the link on the current browser tab: `<a target="_self" href="">Self Tab</a>`
`_blank` it will open the link on a new browser tab: `<a target="_blank" href="">Blank Tab</a>`

#### How should this be manually tested?

#### Screenshots or example usage
```
"sectionLinks": [
	{
		"__editorItemTitle": "Institucional",
		"title": "Institucional",
		"links": [
			{
				"__editorItemTitle": "Quem somos",
				"title": "Quem somos",
				"url": "https://docs.google.com/document/d/1CGSgnXDHSC9TcGeXgQq3pmK98ACk_I8wIdRrrOA0DO4/edit",
				"target": "_self"
			},
			{
				"__editorItemTitle": "Termos e condições",
				"title": "Termos e condições",
				"url": "https://docs.google.com/document/d/1IyJQl0mmY1rr94TpTXil36mmGScCihD72SZRCxOb5Gg/edit",
				"target": "_blank"
			}
		]
	}
]
```

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.