### PR TITLE
Fix: withImage HoC changes image when updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `withImage` now updates image when props are changed.
+
 ## [2.6.15] - 2019-03-26
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.16] - 2019-04-03
+
 ### Fixed
 
 - `withImage` now updates image when props are changed.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-footer",
-  "version": "2.6.15",
+  "version": "2.6.16",
   "title": "VTEX Store Footer component",
   "defaultLocale": "pt-BR",
   "description": "The canonical VTEX store footer component",

--- a/react/__tests__/Footer.test.js
+++ b/react/__tests__/Footer.test.js
@@ -89,4 +89,8 @@ describe('<Footer /> component', () => {
       expect(getByText(title)).toBeTruthy()
     })
   })
+
+  it('should export static schema with title', () => {
+    expect(Footer.schema).toEqual(expect.objectContaining({title: expect.any(String)}))
+  })
 })

--- a/react/components/withImage.js
+++ b/react/components/withImage.js
@@ -19,10 +19,21 @@ export default getImageFilename => {
 
       state = {}
 
-      componentDidMount() {
+      async componentDidMount() {
         const imageName = getImageFilename(this.props)
-        import(`../images/${imageName}`).then(imageSrc => {
-          this.setState({ imageSrc: imageSrc.default })
+        await this.lazyImport(imageName)
+      }
+
+      async componentDidUpdate() {
+        const imageName = getImageFilename(this.props)
+        if (imageName !== this.state.imageName) {
+          await this.lazyImport(imageName)
+        }
+      }
+
+      lazyImport = (imageName) => {
+        return import(`../images/${imageName}`).then(imageSrc => {
+          this.setState({ imageSrc: imageSrc.default, imageName })
         })
       }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add `componentDidUpdate` lifecycle to `withImage` HoC.

#### What problem is this solving?
When the footer props was changed on the site editor, the footer wouldn't change the image (color -> b&w, b&w -> color).

#### How should this be manually tested?
1. Access [Workspace](https://updatefooterimage--storecomponents.myvtex.com/).
2. Inspect footer with React DevTools.
3. Toggle any of the props: `showPaymentFormsInColor`, `showSocialNetworksInColor`, `showVtexLogoInColor`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

