### PR TITLE
Fix intl prop undefined in list item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+- Intl prop undefined in `FooterLinkItem`.
 
 ## [2.13.0] - 2019-05-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.13.1] - 2019-05-28
 ### Fix
 - Intl prop undefined in `FooterLinkItem`.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-footer",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "title": "VTEX Store Footer component",
   "defaultLocale": "pt-BR",
   "description": "The canonical VTEX store footer component",

--- a/react/legacy/FooterLinkList.js
+++ b/react/legacy/FooterLinkList.js
@@ -6,7 +6,7 @@ import { IOMessage, formatIOMessage } from 'vtex.native-types'
 import footerList from './footerList'
 import footer from './footer.css'
 
-export const FooterLinkItem = ({ url, title, target, intl }) =>
+const FooterLinkItem = ({ url, title, target, intl }) =>
   title ? (
     <a
       className={`${
@@ -28,4 +28,8 @@ FooterLinkItem.propTypes = {
   intl: intlShape,
 }
 
-export default footerList(injectIntl(FooterLinkItem))
+const FooterLinkItemWithIntl = injectIntl(FooterLinkItem)
+
+export { FooterLinkItemWithIntl as FooterLinkItem }
+
+export default footerList(FooterLinkItemWithIntl)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the injectIntl hoc to the list item component.

#### What problem is this solving?
Fix `intl` prop being `undefined` sometimes.

#### How should this be manually tested?
[workspace](https://lucas2--storecomponents.myvtex.com/).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

