### PR TITLE
Add absolute path for footer content schema reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.13.2] - 2019-06-05
 ### Fixed
 - Absolute path for contentSchema Footer definition
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Absolute path for contentSchema Footer definition
+
 
 ## [2.13.1] - 2019-05-28
 ### Fix

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-footer",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "title": "VTEX Store Footer component",
   "defaultLocale": "pt-BR",
   "description": "The canonical VTEX store footer component",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -6,7 +6,7 @@
     ],
     "component": "Footer",
     "content": {
-      "$ref": "#/definitions/Footer"
+      "$ref": "app:vtex.store-footer#/definitions/Footer"
     }
   },
   "footer-layout": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Add absolute path for footer content schema reference to avoid interface inheritance errors
like this: `Error resolving $ref pointer “app:consul.consul-atendimento@0.x#/definitions/Footer”. Token “Footer” does not exist.`

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
https://footerschema--storecomponents.myvtex.com

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

