### PR TITLE
Fix social network enum type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove `native-type text` from `socialNetwork` contentSchema prop
 
 ## [2.15.0] - 2019-07-01
 ### Changed

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -21,7 +21,6 @@
               },
               "socialNetwork": {
                 "title": "admin/editor.footer.socialNetworks.title",
-                "$ref": "app:vtex.native-types#/definitions/text",
                 "default": "Facebook",
                 "enum": ["Facebook", "Twitter", "Instagram", "Youtube"]
               }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Removed `"$ref": "app:vtex.native-types#/definitions/text"` from socialNetwork contentSchema

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Enums shouldn't be set as `"$ref": "app:vtex.native-types#/definitions/text"`, this fails contentSchema validation. If a translation to enum name is needed, it should be passed on the field `enumNames`.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

