### PR TITLE
Fix/legacy menu expand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue on legacy mobile-mode menu, where clicking on it wouldn't expand the accordion menu.
 
 ## [2.16.0] - 2019-07-29
 

--- a/react/legacy/Accordion.js
+++ b/react/legacy/Accordion.js
@@ -22,7 +22,7 @@ class Accordion extends Component {
   }
 
   handleClick = () => {
-    this.setState({ open: !open })
+    this.setState(({ open }) => ({ open: !open }))
   }
 
   translate = id => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes issue on legacy mobile-mode menu, where clicking on it wouldn't expand the accordion menu.

Before (only on mobile mode):
https://biscoind.myvtex.com/

After (only on mobile mode):
https://lbebber--biscoind.myvtex.com/
<!--- Describe your changes in detail. -->

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

