### PR TITLE
Allow sandbox app to be used on footer

### DIFF
--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -25,7 +25,8 @@
       "rich-text",
       "image",
       "flex-layout",
-      "shop-review-badge"
+      "shop-review-badge",
+      "sandbox"
     ]
   },
   "footer-layout.mobile": {},


### PR DESCRIPTION
The only way to add Facebook Likebox is using Sandbox App

#### What is the purpose of this pull request?
To allowthe Sandbox App to be used on footer

#### What problem is this solving?
The only way to add Facebook likebox is using the Sandbox app, usually the code is placed in the footer section.

#### How should this be manually tested?
Placing a sandbox app inside the footer

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.

