### PR TITLE
Add default blocks implementation for the footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Default blocks implementation for `footer` block.
 
 ## [2.17.2] - 2019-10-18
 

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1,0 +1,25 @@
+{
+  "footer": {
+    "blocks": ["footer-layout.mobile", "footer-layout.desktop"]
+  },
+  "footer-layout.mobile": {
+    "children": ["flex-layout.row#powered-by"]
+  },
+  "footer-layout.desktop": {
+    "children": ["flex-layout.row#powered-by"]
+  },
+
+  "flex-layout.row#powered-by": {
+    "children": ["flex-layout.col#powered-by"],
+    "props": {
+      "paddingTop": 4,
+      "paddingBottom": 4
+    }
+  },
+  "flex-layout.col#powered-by": {
+    "children": ["powered-by"],
+    "props": {
+      "horizontalAlign": "center"
+    }
+  }
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a clean default blocks implementation for the `footer` block.

#### What problem is this solving?

There was no default implementation for the footer, so a store with no `theme` installed would look pretty weird.

#### How should this be manually tested?

https://defaultblocks--storecomponents.myvtex.com/

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

