### PR TITLE
Fix showInColors prop of social-networks block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prop `showInColors` of `social-networks`.
 
 ## [2.18.0] - 2019-12-02
 ### Added

--- a/react/SocialNetworks.tsx
+++ b/react/SocialNetworks.tsx
@@ -23,6 +23,7 @@ const CSS_HANDLES = [
 
 const SocialNetworks: StorefrontFunctionComponent<Props> = ({
   title,
+  showInColor,
   socialNetworks = [],
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
@@ -38,7 +39,9 @@ const SocialNetworks: StorefrontFunctionComponent<Props> = ({
         {socialNetworks.map(socialNetworkData => (
           <SocialNetwork
             key={socialNetworkData.name + socialNetworkData.url}
-            {...socialNetworkData}
+            showInColor={showInColor}
+            url={socialNetworkData.url}
+            name={socialNetworkData.name}
           />
         ))}
       </div>


### PR DESCRIPTION
#### What problem is this solving?

Previously this didn't work:

```json
  "social-networks": {
    "props": {
      "socialNetworks": [
        { "name": "Facebook", "url": "https://facebook.com" },
        { "name": "Instagram", "url": "https://instagram.com" },
        { "name": "Twitter", "url": "https://twitter.com" }
      ],
      "showInColor": true
    }
  }
```

#### How should this be manually tested?

https://breno--appliancetheme.myvtex.com/

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/70198454-b0f30c00-16ed-11ea-976b-fcd3e68e107d.png)


#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

