### PR TITLE
Fix/partial hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixes bug where `__fold__.experimentalLazyAssets` combined with the regular `__fold__` wouldn't render the footer properly.
 
 ## [2.20.0] - 2020-03-20
 ### Changed

--- a/react/Footer.js
+++ b/react/Footer.js
@@ -21,7 +21,9 @@ const Footer = props => {
   const { isMobile } = useDevice()
 
   if (!shouldRenderBelowTheFold) {
-    return null
+    /** This is a placeholder for view detection work properly when the
+     * footer hasn't rendered yet (for things such as partial hydration) */
+    return <div style={{ height: 400 }} />
   }
 
   const hasFooterLayout = hasFooterDesktop || hasFooterMobile


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes bug where `__fold__.experimentalLazyAssets` combined with the regular `__fold__` wouldn't render the footer properly.

Partially pre-existing, exacerbated by https://github.com/vtex-apps/render-runtime/pull/505

To test, go to https://www.als.com/?workspace=lbebberprod1 and scroll down. The footer should be visible in normal circumstances.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

